### PR TITLE
refactor(ImageData): remove `defaultImage`,fix(QRResImage): use crossOrigin to fix cross-origin warning

### DIFF
--- a/src/components/QRImage.tsx
+++ b/src/components/QRImage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {rand, defaultViewBox} from '../utils/helper';
 import { getTypeTable, QRPointType } from '../utils/qrcodeHandler';
 import {RendererWrapper, RendererProps, SFC} from './RendererWrapper';
-import {defaultImage} from "../static/ImageData";
 
 enum Type {
     Rect = 'rect',
@@ -137,7 +136,7 @@ QRImage.defaultCSS = {
 }
 
 QRImage.defaultProps =  {
-    image: defaultImage,
+    image: "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
     type: Type.Rect,
     size: 100,
     opacity: 100,

--- a/src/components/QRResImage.tsx
+++ b/src/components/QRResImage.tsx
@@ -1,7 +1,6 @@
 import React, {useMemo, useState} from 'react';
 import { getTypeTable, QRPointType } from '../utils/qrcodeHandler';
 import {RendererWrapper, RendererProps, SFC} from './RendererWrapper';
-import {defaultResImage} from "../static/ImageData";
 import QRCode from "../utils/qrcode";
 import {gamma} from "../utils/helper";
 
@@ -54,6 +53,11 @@ function getGrayPointList({ image, contrast, exposure }: QRResImageProps, size: 
     size *= 3;
 
     img.src = image!;
+    /**
+     * 使用 crossOrigin 属性可以让 canvas 支持绘制非当前域名下的图片，比如 CDN 上的图片资源
+     * ios 10.2 版本对本地图片资源不允许使用 crossOrigin 属性，因此需要使用以下兼容代码
+     */
+    if (image && /^http(s)?:\/\//.test(image)) img.crossOrigin = 'anonymous'
     contrast = contrast! / 100;
     exposure = exposure! / 100;
     return new Promise<typeof gpl>(resolve => {
@@ -155,7 +159,7 @@ QRResImage.defaultCSS = {
 }
 
 QRResImage.defaultProps =  {
-    image: defaultResImage,
+    image: "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
     contrast: 0,
     exposure: 0,
     alignType: Type.None,


### PR DESCRIPTION
目前项目中的 `defaultImage` 体积过大，并且项目组件中以依赖方式引入，这会导致图片被打包进 `dist/index.js` 文件中。项目中的 ImageData 如果只是出于二维码效果演示用途，我觉得这么的代价过大，特别是在移动端的场景下，项目依赖大小对于页面的加载影响较大。
我试图通过一张 1px 的 base64 透明图片来替换原有的 ImageData，打包后的文件体积从 200kb 降到了 89kb，效果非常理想。
此外，我还发现了 QRResImage 组件没有对跨域图片做兼容。当我引用一张 CDN 上的图片资源（这种场景在项目开发中比较常见）时，会被 Chrome 浏览器提示 canvas 图片绘制时引用了跨域的图片，引发了安全警告，但可以通过设置 img 的 crossOrigin 属性来解决这个问题。
此外，我对项目还有一些其他方面的优化，如果你 merge 了这个 PR，我会考虑陆续提交其他方面的改动。